### PR TITLE
Modify TM4B.config attributes instead of setting attributes for Client

### DIFF
--- a/lib/tm4b/client.rb
+++ b/lib/tm4b/client.rb
@@ -7,12 +7,8 @@ module TM4B
    class Client
       BaseURI = URI.parse("http://www.tm4b.com/client/api/http.php").freeze
 
-      attr_accessor :username, :password, :use_ssl
-
       def initialize(options={})
-         @username = options.fetch(:username, TM4B.config.username)
-         @password = options.fetch(:password, TM4B.config.password)
-         @use_ssl  = options.fetch(:use_ssl,  TM4B.config.use_ssl)
+         options.each{|key, value| TM4B.config.send("#{key}=", value)}
       end
 
       #
@@ -109,10 +105,10 @@ module TM4B
       def request(params)
          req = Net::HTTP::Post.new("/client/api/http.php")
          
-         req.set_form_data params.merge(:username => username, :password => password)
+         req.set_form_data params.merge(:username => TM4B.config.username, :password => TM4B.config.password)
          
-         conn = Net::HTTP.new("www.tm4b.com", use_ssl ? 443 : 80)
-         conn.use_ssl = use_ssl
+         conn = Net::HTTP.new("www.tm4b.com", TM4B.config.use_ssl ? 443 : 80)
+         conn.use_ssl = TM4B.config.use_ssl
          conn.start {|http| http.request(req) }
       end
 

--- a/lib/tm4b/configuration.rb
+++ b/lib/tm4b/configuration.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 module TM4B
-   class Configuration
-      attr_accessor :username, :password, :use_ssl
+   class Configuration < Struct.new(:username, :password, :use_ssl)
    end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -9,16 +9,16 @@ describe TM4B::Client do
       TM4B.config.use_ssl  = true
    end
 
-   it 'should accept options for an overridden username, password and ssl' do
+   it 'should accept options to override username, password and ssl' do
       default_client = TM4B::Client.new
-      default_client.username.should == "foo"
-      default_client.password.should == "bar"
-      default_client.use_ssl.should == true
+      TM4B.config.username.should == "foo"
+      TM4B.config.password.should == "bar"
+      TM4B.config.use_ssl.should == true
 
       overridden_client = TM4B::Client.new :username => "one", :password => "two", :use_ssl => false
-      overridden_client.username.should == "one"
-      overridden_client.password.should == "two"
-      overridden_client.use_ssl.should  == false
+      TM4B.config.username.should == "one"
+      TM4B.config.password.should == "two"
+      TM4B.config.use_ssl.should  == false
    end
 
    context "broadcasting a message" do


### PR DESCRIPTION
Client initializer method now modifies TM4B.config attributes instead of
setting :username, :client and :use_ssl attributes for Client instances.
This allows to remove references to these attributes in the Client request
method which in turn will facilitate further refactoring.
