### PR TITLE
Dont force ActiveSupport Version

### DIFF
--- a/lib/tm4b/broadcast.rb
+++ b/lib/tm4b/broadcast.rb
@@ -1,6 +1,8 @@
 # encoding: utf-8
 
 require 'rexml/document'
+require 'active_support/multibyte/chars'
+require 'active_support/multibyte/unicode'
 
 module TM4B
    class Broadcast
@@ -42,7 +44,7 @@ module TM4B
           encode!("UTF-8")
 
         if @encoding.to_s == "plain"
-          ActiveSupport::Multibyte.proxy_class.new(@message).
+          ActiveSupport::Multibyte::Chars.new(@message).
             gsub("€", "E").
             normalize(:kd).
             gsub(/[^\x00-\x7F]/,'').

--- a/tm4b.gemspec
+++ b/tm4b.gemspec
@@ -24,14 +24,14 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rake"
 
-  s.add_development_dependency "rspec", ">= 2.6.0"
+  s.add_development_dependency "rspec", "~> 2.6.0"
   s.add_development_dependency "fakeweb", ">= 1.3.0"
 
   # to make testing more fun (if only it needed less configuration)
   s.add_development_dependency "guard"
   s.add_development_dependency "guard-rspec"
 
-  s.add_dependency "activesupport", "~> 3.0"
+  s.add_dependency "activesupport"
 
   if RUBY_PLATFORM =~ /darwin/i
     # filesystem event support for OSX


### PR DESCRIPTION
Tested with ActiveSupport 3 & 4. Change to Char required. Locking RSpec
due to Syntax changes.
