### PR TITLE
Replace undefined chars by empty string

### DIFF
--- a/lib/tm4b/broadcast.rb
+++ b/lib/tm4b/broadcast.rb
@@ -40,7 +40,7 @@ module TM4B
 
       def encoded_message
         @message.
-          encode!("ISO-8859-1", :invalid => :replace, :replace => "").
+          encode!("ISO-8859-1", :invalid => :replace, :undef => :replace, :replace => "").
           encode!("UTF-8")
 
         if @encoding.to_s == "plain"

--- a/spec/broadcast_spec.rb
+++ b/spec/broadcast_spec.rb
@@ -8,21 +8,27 @@ describe TM4B::Broadcast do
       @broadcast.originator = "tm4btest"
       @broadcast.message = "hello world"
    end
-   
+
    it "should return an encoded string if 'plain' encoding if selected" do
      @broadcast.message = "ÀÁÂÃÄÅÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝàáâãäåçèéêëìíîïñòóôõöùúûüýÿ"
      @broadcast.encoding = :plain
      @broadcast.parameters["msg"].should == "AAAAAACEEEEIIIINOOOOOUUUUYaaaaaaceeeeiiiinooooouuuuyy"
    end
-   
+
    it "should return valid string even if it's not UTF8 compliant" do
      @broadcast.message = "\xE2"
      @broadcast.encoding = :plain
      @broadcast.parameters["msg"].should == ""
    end
-   
+
    it "should return valid string even if it's not UTF8 compliant" do
      @broadcast.message = "\xE2"
+     @broadcast.encoding = :unicode
+     @broadcast.parameters["msg"].should == ""
+   end
+
+   it "should replace undefined chars by nothing" do
+     @broadcast.message = "’"
      @broadcast.encoding = :unicode
      @broadcast.parameters["msg"].should == ""
    end


### PR DESCRIPTION
Some chars can't be converted in ASCII because there is no equivalence.

For instance the following character : [`’`](http://www.fileformat.info/info/unicode/char/2019/index.htm)

Setting the `:undef` options ignores them. This prevents the following exception to occur when trying the conversion.

```
Encoding::UndefinedConversionError: U+2019 from UTF-8 to ISO-8859-1
```
